### PR TITLE
Allow conduit 1.2 versions

### DIFF
--- a/binary-conduit.cabal
+++ b/binary-conduit.cabal
@@ -19,7 +19,7 @@ library
   exposed-modules:     
     Data.Conduit.Serialization.Binary
   build-depends:       base >=4 && <5,
-                       conduit >= 1.1 && < 1.2,
+                       conduit >= 1.1 && < 1.3,
                        bytestring >= 0.9 && < 10.3,
                        binary >= 0.6 && < 0.8,
                        vector >= 0.10,


### PR DESCRIPTION
I haven't done any rigorous testing, but everything seems to work fine with the conduit 1.2.
