### PR TITLE
Latest release requires bytestring >= 0.9.2

### DIFF
--- a/binary-conduit.cabal
+++ b/binary-conduit.cabal
@@ -20,7 +20,7 @@ library
     Data.Conduit.Serialization.Binary
   build-depends:       base >=4 && <5,
                        conduit >= 1.1 && < 1.3,
-                       bytestring >= 0.9 && < 10.3,
+                       bytestring >= 0.9.2 && < 10.3,
                        binary >= 0.6 && < 0.8,
                        vector >= 0.10,
                        resourcet >= 1.1


### PR DESCRIPTION
Build error can be seen here: http://matrix.hackage.haskell.org/package/binary-conduit#GHC-7.4/binary-conduit-1.2.3

I revised the 1.2.3 release: https://hackage.haskell.org/package/binary-conduit-1.2.3/revisions/
