### PR TITLE
Fix Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ The binary-conduit package.
 
 [Hackage Version Image]: http://img.shields.io/hackage/v/binary-conduit.svg
 [Hackage package]: http://hackage.haskell.org/package/binary-conduit
-[Build Status Image]: https://travis-ci.org/qnikst/conduit-binary.svg
-[Build Status]: https://travis-ci.org/qnikst/conduit-binary.svg
+[Build Status Image]: https://travis-ci.org/qnikst/binary-conduit.svg
+[Build Status]: https://travis-ci.org/qnikst/binary-conduit.svg
 
 Allow binary serialization [1] using iterative conduit [2] interface.
 


### PR DESCRIPTION
Seems that binary-conduit was renamed from conduit-binary and Travis link was broken.