### PR TITLE
Loosen the MonadThrow restriction on Putters to Monad

### DIFF
--- a/Data/Conduit/Serialization/Binary.hs
+++ b/Data/Conduit/Serialization/Binary.hs
@@ -98,31 +98,31 @@ name = conduit \
                     Just x  -> do { yi ; conduit}}
 
 -- | Runs putter repeatedly on a input stream, returns an output stream.
-conduitPut :: MonadThrow m => Conduit Put m ByteString
+conduitPut :: Monad m => Conduit Put m ByteString
 conduitPutGeneric(conduitPut, (sourcePut x $$ CL.mapM_ yield))
 
 -- | Runs a putter repeatedly on a input stream, returns a packets.
-conduitMsg :: MonadThrow m => Conduit Put m ByteString
+conduitMsg :: Monad m => Conduit Put m ByteString
 conduitPutGeneric(conduitMsg, (yield (LBS.toStrict $ runPut x)))
 
 -- | Runs putter repeatedly on a input stream.
 -- Returns a lazy butestring so it's possible to use vectorized
 -- IO on the result either by calling' LBS.toChunks' or by 
 -- calling 'Network.Socket.ByteString.Lazy.send'.
-conduitPutLBS :: MonadThrow m => Conduit Put m LBS.ByteString
+conduitPutLBS :: Monad m => Conduit Put m LBS.ByteString
 conduitPutGeneric(conduitPutLBS, yield (runPut x))
 
 -- | Vectorized variant of 'conduitPut' returning list contains
 -- all chunks from one element representation
-conduitPutList :: MonadThrow m => Conduit Put m [ByteString]
+conduitPutList :: Monad m => Conduit Put m [ByteString]
 conduitPutGeneric(conduitPutList, yield (LBS.toChunks (runPut x)))
 
 -- | Vectorized variant of 'conduitPut'.
-conduitPutMany :: MonadThrow m => Conduit Put m (V.Vector ByteString)
+conduitPutMany :: Monad m => Conduit Put m (V.Vector ByteString)
 conduitPutGeneric(conduitPutMany, yield (V.fromList (LBS.toChunks (runPut x))))
 
 -- | Create stream of strict bytestrings from 'Put' value.
-sourcePut :: MonadThrow m => Put -> Producer m ByteString
+sourcePut :: Monad m => Put -> Producer m ByteString
 sourcePut = CL.sourceList . LBS.toChunks . runPut
 
 -- | Decode message from input stream.

--- a/binary-conduit.cabal
+++ b/binary-conduit.cabal
@@ -1,5 +1,5 @@
 name:                binary-conduit
-version:             1.2.4
+version:             1.2.4.1
 synopsis:            data serialization/deserialization conduit library
 description:         The binary-conduit package.
       Allow binary serialization using iterative conduit interface.
@@ -7,7 +7,7 @@ license:             MIT
 license-file:        LICENSE
 author:              Alexander Vershilov
 maintainer:          alexander.vershilov@gmail.com
-copyright:           2013 Alexander Vershilov
+copyright:           2013-2016 Alexander Vershilov
 category:            Conduit
 stability:           Experimental
 homepage:            http://github.com/qnikst/binary-conduit/
@@ -16,12 +16,12 @@ build-type:          Simple
 cabal-version:       >=1.8
 
 library
-  exposed-modules:     
+  exposed-modules:
     Data.Conduit.Serialization.Binary
   build-depends:       base >=4 && <5,
                        conduit >= 1.1 && < 1.3,
                        bytestring >= 0.9.2 && < 10.3,
-                       binary >= 0.6 && < 0.8,
+                       binary >= 0.6 && < 0.9,
                        vector >= 0.10,
                        resourcet >= 1.1
   ghc-options: -Wall


### PR DESCRIPTION
There seems to be no reason the put functions wouldn't work with any monad (unless I'm missing something), so allow them to.

Also updates the package description from what's currently on hackage.